### PR TITLE
Update actions/checkout to v7 (Node 24 runtime)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,7 +12,7 @@ jobs:
       contents: write
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` from v4 to v7 in the Quarto publish workflow — v4 runs on the deprecated Node 20 runtime; v7 (June 2026) runs on Node 24.
- `quarto-dev/quarto-actions/setup@v2` and `publish@v2` are left unchanged: both are composite (shell-only) actions with no Node runtime, and the `v2` tag currently points at the latest release (v2.2.0, Nov 2025).
- No `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env var added — with checkout on v7 there are no Node 20 actions left, so the transitional knob would be dead config.

## Notes
- checkout v5–v7 breaking changes reviewed: v6 credential-file change and v7 fork-PR block for `pull_request_target` don't affect this workflow (push to main + manual dispatch only).
- The workflow only triggers on main, so the first real run happens after merge — worth watching that Quarto Publish run.

